### PR TITLE
Add users DynamoDB table ARN output and update IAM policies

### DIFF
--- a/database/outputs.tf
+++ b/database/outputs.tf
@@ -1,6 +1,10 @@
-# output "users-dynamodb-table-arn" {
-#   value = aws_dynamodb_table.users-dynamodb-table.arn
-# }
+output "users-dynamodb-table-arn" {
+  value = aws_dynamodb_table.users-dynamodb-table.arn
+}
+
+output "users-dynamodb-table-name" {
+  value = aws_dynamodb_table.users-dynamodb-table.name
+}
 
 output "trips-dynamodb-table-name" {
   value = aws_dynamodb_table.trips-dynamodb-table.name

--- a/iam/custom_iam_policies.tf
+++ b/iam/custom_iam_policies.tf
@@ -7,7 +7,7 @@ resource "aws_iam_role_policy" "dynamodb-lambda-policy" {
       {
         "Effect" : "Allow",
         "Action" : ["dynamodb:*"],
-        "Resource" : "${var.trips-dynamodb-table-arn}"
+        "Resource" : ["${var.trips-dynamodb-table-arn}", "${var.users-dynamodb-table-arn}"]
       }
     ]
   })

--- a/iam/variables.tf
+++ b/iam/variables.tf
@@ -13,6 +13,11 @@ variable "trips-dynamodb-table-arn" {
   type = string
 }
 
+variable "users-dynamodb-table-arn" {
+  type = string
+}
+
+
 variable "cognito_identity_pool_id" {
   type = string
 }

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ module "iam" {
   trips-dynamodb-table-arn = module.database.trips-dynamodb-table-arn
   cognito_identity_pool_id = module.cognito.cognito_identity_pool_id
   apigateway_id            = module.networking.apigateway_id
+  users-dynamodb-table-arn = module.database.users-dynamodb-table-arn
 }
 
 module "networking" {


### PR DESCRIPTION
Add output for the users DynamoDB table ARN and include it in the IAM policies. This change enhances the configuration by providing necessary outputs and permissions for the users table.